### PR TITLE
Added interface for external cores

### DIFF
--- a/rtl/soc.v
+++ b/rtl/soc.v
@@ -8,14 +8,30 @@
 `include "neorv32_wrapper.v"
 
 
-module soc (
+module soc #(
+    // Set EXT_MASTER_COUNT and EXT_SLAVE_COUNT to enable master and slave ports for external cores.
+    parameter EXT_MASTER_COUNT = 0,
+    parameter EXT_SLAVE_COUNT = 0
+) (
     input sys_clk,
     input sys_rst,
+
+    `WISHBONE_MASTER_ARRAY(ext_masters, EXT_MASTER_COUNT),
+    `WISHBONE_SLAVE_ARRAY(ext_slaves, EXT_SLAVE_COUNT),
 
     output uart0_tx,
     input uart0_rx,
     output [63:0] gpio_out
 );
+
+    // Master and Slave Counts
+    //
+
+    localparam INT_MASTER_COUNT = 1;
+    localparam INT_SLAVE_COUNT = 2;
+
+    localparam MASTER_COUNT = (EXT_MASTER_COUNT != 0 ? EXT_MASTER_COUNT : 1) + INT_MASTER_COUNT;
+    localparam SLAVE_COUNT = EXT_SLAVE_COUNT + INT_SLAVE_COUNT;
 
     // Slave Address Ranges
     //
@@ -38,41 +54,79 @@ module soc (
     // Interconnect
     //
     
-    `WISHBONE_WIRES(dummy);
+    generate 
 
-    interconnect #(
-        .DATA_WIDTH(32),
-        .ADDR_WIDTH(32),
-        .MASTER_COUNT(2),
-        .SLAVE_COUNT(2),
-        .SLAVE_ADDR({ROM0_ADDR, BRAM0_ADDR}),
-        .SLAVE_MASK({ROM0_MASK, BRAM0_MASK})
-    ) interconnect0 (
-        .sys_clk(sys_clk),
-        .sys_rst(sys_rst),
+    if (EXT_MASTER_COUNT == 0) begin
+        `WISHBONE_WIRES(dummy);
+        interconnect #(
+            .DATA_WIDTH(32),
+            .ADDR_WIDTH(32),
+            .MASTER_COUNT(MASTER_COUNT),
+            .SLAVE_COUNT(SLAVE_COUNT),
+            .SLAVE_ADDR({ROM0_ADDR, BRAM0_ADDR}),
+            .SLAVE_MASK({ROM0_MASK, BRAM0_MASK})
+        ) interconnect0 (
+            .sys_clk(sys_clk),
+            .sys_rst(sys_rst),
 
-        .master_cyc ({dummy_cyc ,  cpu0_cyc }),
-        .master_stb ({dummy_stb ,  cpu0_stb }),
-        .master_we  ({dummy_we  ,  cpu0_we  }),
-        .master_tag ({dummy_tag ,  cpu0_tag }),
-        .master_sel ({dummy_sel ,  cpu0_sel }),
-        .master_adr ({dummy_adr ,  cpu0_adr }),
-        .master_mosi({dummy_mosi,  cpu0_mosi}),
-        .master_miso({dummy_miso,  cpu0_miso}),
-        .master_ack ({dummy_ack ,  cpu0_ack }),
-        .master_err ({dummy_err ,  cpu0_err }),
+            .master_cyc ({dummy_cyc ,  cpu0_cyc }),
+            .master_stb ({dummy_stb ,  cpu0_stb }),
+            .master_we  ({dummy_we  ,  cpu0_we  }),
+            .master_tag ({dummy_tag ,  cpu0_tag }),
+            .master_sel ({dummy_sel ,  cpu0_sel }),
+            .master_adr ({dummy_adr ,  cpu0_adr }),
+            .master_mosi({dummy_mosi,  cpu0_mosi}),
+            .master_miso({dummy_miso,  cpu0_miso}),
+            .master_ack ({dummy_ack ,  cpu0_ack }),
+            .master_err ({dummy_err ,  cpu0_err }),
 
-        .slave_cyc ({rom0_cyc,  bram0_cyc}),
-        .slave_stb ({rom0_stb,  bram0_stb}),
-        .slave_we  ({rom0_we,   bram0_we}),
-        .slave_tag ({rom0_tag,  bram0_tag}),
-        .slave_sel ({rom0_sel,  bram0_sel}),
-        .slave_adr ({rom0_adr,  bram0_adr}),
-        .slave_mosi({rom0_mosi, bram0_mosi}),
-        .slave_miso({rom0_miso, bram0_miso}),
-        .slave_ack ({rom0_ack,  bram0_ack}),
-        .slave_err ({rom0_err,  bram0_err})
-    );
+            .slave_cyc ({rom0_cyc , bram0_cyc , ext_slaves_cyc }),
+            .slave_stb ({rom0_stb , bram0_stb , ext_slaves_stb }),
+            .slave_we  ({rom0_we  , bram0_we  , ext_slaves_we  }),
+            .slave_tag ({rom0_tag , bram0_tag , ext_slaves_tag }),
+            .slave_sel ({rom0_sel , bram0_sel , ext_slaves_sel }),
+            .slave_adr ({rom0_adr , bram0_adr , ext_slaves_adr }),
+            .slave_mosi({rom0_mosi, bram0_mosi, ext_slaves_mosi}),
+            .slave_miso({rom0_miso, bram0_miso, ext_slaves_miso}),
+            .slave_ack ({rom0_ack , bram0_ack , ext_slaves_ack }),
+            .slave_err ({rom0_err , bram0_err , ext_slaves_err })
+        );
+    end else begin
+        interconnect #(
+            .DATA_WIDTH(32),
+            .ADDR_WIDTH(32),
+            .MASTER_COUNT(MASTER_COUNT),
+            .SLAVE_COUNT(SLAVE_COUNT),
+            .SLAVE_ADDR({ROM0_ADDR, BRAM0_ADDR}),
+            .SLAVE_MASK({ROM0_MASK, BRAM0_MASK})
+        ) interconnect0 (
+            .sys_clk(sys_clk),
+            .sys_rst(sys_rst),
+
+            .master_cyc ({cpu0_cyc , ext_masters_cyc }),
+            .master_stb ({cpu0_stb , ext_masters_stb }),
+            .master_we  ({cpu0_we  , ext_masters_we  }),
+            .master_tag ({cpu0_tag , ext_masters_tag }),
+            .master_sel ({cpu0_sel , ext_masters_sel }),
+            .master_adr ({cpu0_adr , ext_masters_adr }),
+            .master_mosi({cpu0_mosi, ext_masters_mosi}),
+            .master_miso({cpu0_miso, ext_masters_miso}),
+            .master_ack ({cpu0_ack , ext_masters_ack }),
+            .master_err ({cpu0_err , ext_masters_err }),
+
+            .slave_cyc ({rom0_cyc , bram0_cyc , ext_slaves_cyc }),
+            .slave_stb ({rom0_stb , bram0_stb , ext_slaves_stb }),
+            .slave_we  ({rom0_we  , bram0_we  , ext_slaves_we  }),
+            .slave_tag ({rom0_tag , bram0_tag , ext_slaves_tag }),
+            .slave_sel ({rom0_sel , bram0_sel , ext_slaves_sel }),
+            .slave_adr ({rom0_adr , bram0_adr , ext_slaves_adr }),
+            .slave_mosi({rom0_mosi, bram0_mosi, ext_slaves_mosi}),
+            .slave_miso({rom0_miso, bram0_miso, ext_slaves_miso}),
+            .slave_ack ({rom0_ack , bram0_ack , ext_slaves_ack }),
+            .slave_err ({rom0_err , bram0_err , ext_slaves_err })
+        );
+    end
+    endgenerate
 
     // CPU0
     //

--- a/rtl/soc.v
+++ b/rtl/soc.v
@@ -16,8 +16,8 @@ module soc #(
     input sys_clk,
     input sys_rst,
 
-    `WISHBONE_MASTER_ARRAY(ext_masters, EXT_MASTER_COUNT),
-    `WISHBONE_SLAVE_ARRAY(ext_slaves, EXT_SLAVE_COUNT),
+    `WISHBONE_SLAVE_ARRAY(ext_masters, EXT_MASTER_COUNT),
+    `WISHBONE_MASTER_ARRAY(ext_slaves, EXT_SLAVE_COUNT),
 
     output uart0_tx,
     input uart0_rx,

--- a/rtl/utils/wishbone.v
+++ b/rtl/utils/wishbone.v
@@ -3,12 +3,13 @@
 // Note that these macros omit syscon signals, they will need to be manually
 // added.
 //
-// Use WISHBONE_WIRES for creating wires to connect two modules.
+// Use WISHBONE_WIRES for creating wires to connect a wishbone master and slave.
 // Use WISHBONE_MASTER to declare inputs and outputs to a wishbone master.
-// Use WISHBONE_SLAVE to declare inputs and outputs to a wishbone master.
+// Use WISHBONE_SLAVE to declare inputs and outputs to a wishbone slave.
+// Use WISHBONE_WIRES_ARRAY for creating wires to connect multiple wishbone masters and slaves.
+// Use WISHBONE_MASTER_ARRAY to declare inputs and outputs to multiple wishbone masters.
+// Use WISHBONE_SLAVE_ARRAY to declare inputs and outputs to multiple wishbone slaves.
 // Use WISHBONE_PORT to connect to a module's wishbone signals.
-// Use WISHBONE_ADDR_RANGE to declare parameters for a wishbone slave's
-// address range.
 
 `define WISHBONE_WIRES(PREFIX) \
     wire PREFIX``_cyc; \
@@ -46,6 +47,42 @@
     output reg PREFIX``_ack, \
     output reg PREFIX``_err
 
+`define WISHBONE_WIRES_ARRAY(PREFIX, COUNT) \
+    wire [COUNT-1:0] PREFIX``_cyc; \
+    wire [COUNT-1:0] PREFIX``_stb; \
+    wire [COUNT-1:0] PREFIX``_we; \
+    wire [COUNT*3-1:0] PREFIX``_tag; \
+    wire [COUNT*4-1:0] PREFIX``_sel; \
+    wire [COUNT*32-1:0] PREFIX``_adr; \
+    wire [COUNT*32-1:0] PREFIX``_mosi; \
+    wire [COUNT*32-1:0] PREFIX``_miso; \
+    wire [COUNT-1:0] PREFIX``_ack; \
+    wire [COUNT-1:0] PREFIX``_err
+
+`define WISHBONE_MASTER_ARRAY(PREFIX, COUNT) \
+    output reg [COUNT-1:0] PREFIX``_cyc, \
+    output reg [COUNT-1:0] PREFIX``_stb, \
+    output reg [COUNT-1:0] PREFIX``_we, \
+    output reg [COUNT*3-1:0] PREFIX``_tag, \
+    output reg [COUNT*4-1:0] PREFIX``_sel, \
+    output reg [COUNT*32-1:0] PREFIX``_adr, \
+    output reg [COUNT*32-1:0] PREFIX``_mosi, \
+    input [COUNT*32-1:0] PREFIX``_miso, \
+    input [COUNT-1:0] PREFIX``_ack, \
+    input [COUNT-1:0] PREFIX``_err
+
+`define WISHBONE_SLAVE_ARRAY(PREFIX, COUNT) \
+    input reg [COUNT-1:0] PREFIX``_cyc, \
+    input reg [COUNT-1:0] PREFIX``_stb, \
+    input reg [COUNT-1:0] PREFIX``_we, \
+    input reg [COUNT*3-1:0] PREFIX``_tag, \
+    input reg [COUNT*4-1:0] PREFIX``_sel, \
+    input reg [COUNT*32-1:0] PREFIX``_adr, \
+    input reg [COUNT*32-1:0] PREFIX``_mosi, \
+    output [COUNT*32-1:0] PREFIX``_miso, \
+    output [COUNT-1:0] PREFIX``_ack, \
+    output [COUNT-1:0] PREFIX``_err
+
 `define WISHBONE_PORT(MODULE_PREFIX, INPUT_PREFIX) \
     .MODULE_PREFIX``_cyc(INPUT_PREFIX``_cyc), \
     .MODULE_PREFIX``_stb(INPUT_PREFIX``_stb), \
@@ -57,9 +94,4 @@
     .MODULE_PREFIX``_miso(INPUT_PREFIX``_miso), \
     .MODULE_PREFIX``_ack(INPUT_PREFIX``_ack), \
     .MODULE_PREFIX``_err(INPUT_PREFIX``_err)
-
-// @todo add assertion that LENGTH must be a power of two
-`define WISHBONE_ADDR_RANGE(WIDTH, SLAVE, ORIGIN, LENGTH) \
-    integer [WIDTH-1:0] SLAVE``_ADDR = WIDTH'(ORIGIN); \
-    integer [WIDTH-1:0] SLAVE``_MASK = WIDTH'(LENGTH - 1)
 


### PR DESCRIPTION
Implemented features to fulfill #1.

**Added:**
- `WISHBONE_WIRES_ARRAY` macro for connecting multiple masters and slaves.
- `WISHBONE_MASTER_ARRAY` macro for module with multiple masters.
- `WISHBONE_SLAVE_ARRAY` macro for module with multiple slaves.
- Ports `ext_masters_<wishbone_signal>` and `ext_slaves_<wishbone_signal>` to soc module.